### PR TITLE
dark color for light background

### DIFF
--- a/widgets/sensu_table/sensu_table.scss
+++ b/widgets/sensu_table/sensu_table.scss
@@ -106,12 +106,14 @@ td
 {
   background-color:#FF0;
   yellowcolor:#000;
+  color: #000000
 }
 
 .unknown
 {
   background-color:orange;
   orangecolor:#000;
+  color: #000000
 }
 
 // Highlight table rows on mouse over


### PR DESCRIPTION
text color needs to be black when the background is yellow or orange (warning or unknown urgency) so that it is visible
