### PR TITLE
WEBOPS-2943 fix rendering of dashboard in safari

### DIFF
--- a/assets/javascripts/updatequery.js
+++ b/assets/javascripts/updatequery.js
@@ -1,4 +1,7 @@
-function UpdateQueryString(value, key='team') {
+function UpdateQueryString(value, key) {
+    if(key === undefined) {
+        key = 'team';
+    }
     url = window.location.href;
     var re = new RegExp("([?&])" + key + "=.*?(&|#|$)(.*)", "gi"),
         hash;


### PR DESCRIPTION
Safari does not yet support default parameters for
functions. This prevents the whole interface rendering.

This fix moves to a more compatible way of defining
default values for parameters.
